### PR TITLE
New parameter dryrun to specify dryrun mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ class{'earlyoom':
   memory_percent  => 20,
   swap_percent    => [10,4]
   memory_size     => 20000,
-  swap_size       => [30000,60000]
+  swap_size       => [30000,60000],
+  dryrun          => false,
 }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -49,7 +49,8 @@ class{'earlyoom':
   memory_percent  => 20,
   swap_percent    => [10,4]
   memory_size     => 20000,
-  swap_size       => [30000,60000]
+  swap_size       => [30000,60000],
+  dryrun          => false,
 }
 ```
 
@@ -188,4 +189,12 @@ SIGKILL once below KILL_PERCENT (default PERCENT/2).
 (-S int or -S int,int
 
 Default value: ``undef``
+
+##### `dryrun`
+
+Data type: `Boolean`
+
+if true dry run (do not kill any processes) (--dryrun)
+
+Default value: ``false``
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class earlyoom::config (
   $swap_percent    = $earlyoom::swap_percent,
   $memory_size     = $earlyoom::memory_size,
   $swap_size       = $earlyoom::swap_size,
+  $dryrun          = $earlyoom::dryrun,
 ) {
   assert_private()
 
@@ -82,6 +83,11 @@ class earlyoom::config (
     default => '',
   }
 
+  $_dryrun = $dryrun ? {
+    true    => '--dryrun',
+    default => '',
+  }
+
   $_options = [
     $_interval,
     $_ignore_positive,
@@ -95,6 +101,7 @@ class earlyoom::config (
     $_swap_percent,
     $_memory_size,
     $_swap_size,
+    $_dryrun,
   ]
 
   file { $configfile:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,8 @@
 #    memory_percent  => 20,
 #    swap_percent    => [10,4]
 #    memory_size     => 20000,
-#    swap_size       => [30000,60000]
+#    swap_size       => [30000,60000],
+#    dryrun          => false,
 #  }
 #
 # @param pkgname
@@ -78,6 +79,9 @@
 #     SIGKILL once below KILL_PERCENT (default PERCENT/2).
 #     (-S int or -S int,int
 #
+# @param dryrun
+#     if true dry run (do not kill any processes) (--dryrun)
+#
 class earlyoom (
   String[1] $pkgname                  = 'earlyoom',
   Stdlib::Unixpath $configfile        = '/etc/default/earlyoom',
@@ -87,6 +91,7 @@ class earlyoom (
   Boolean $notify_send                = false,
   Boolean $debug                      = false,
   Boolean $priority                   = false,
+  Boolean $dryrun                     = false,
   Optional[String[1]] $prefer         = undef,
   Optional[String[1]] $avoid          = undef,
   Optional[String[1]] $notify_command = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -76,6 +76,22 @@ describe 'earlyoom', type: 'class' do
           it { is_expected.to contain_file('/etc/default/earlyoom').with_content(%r{^EARLYOOM_ARGS="-r 60 --avoid '\^\(foo\|bar\)\$'"$}) }
         end
 
+        context 'with dryrun specified false' do
+          let(:params) do
+            { dryrun: false }
+          end
+
+          it { is_expected.to contain_file('/etc/default/earlyoom').with_content(%r{^EARLYOOM_ARGS="-r 60"$}) }
+        end
+
+        context 'with dryrun specified true' do
+          let(:params) do
+            { dryrun: true }
+          end
+
+          it { is_expected.to contain_file('/etc/default/earlyoom').with_content(%r{^EARLYOOM_ARGS="-r 60 --dryrun"$}) }
+        end
+
         context 'with memory_percent TERM only specified' do
           let(:params) do
             { memory_percent: 85 }
@@ -153,11 +169,12 @@ describe 'earlyoom', type: 'class' do
               memory_percent: 22,
               swap_percent: [12, 14],
               memory_size: [4, 5],
-              swap_size: 8
+              swap_size: 8,
+              dryrun: true
             }
           end
 
-          it { is_expected.to contain_file('/etc/default/earlyoom').with_content(%r{^EARLYOOM_ARGS="-r 123 -i -n -d -p --prefer 'alpha' --avoid 'beta' -N '\/foo\/bar' -m 22 -s 12,14 -M 4,5 -S 8"$}) }
+          it { is_expected.to contain_file('/etc/default/earlyoom').with_content(%r{^EARLYOOM_ARGS="-r 123 -i -n -d -p --prefer 'alpha' --avoid 'beta' -N '\/foo\/bar' -m 22 -s 12,14 -M 4,5 -S 8 --dryrun"$}) }
         end
         context 'with pkgname specified' do
           let(:params) do


### PR DESCRIPTION
#### Pull Request (PR) description

By default the new `dryrun` parameter is `false` however if dryrun is specified
`true` then the `--dryrun` option will be added to earlyoom and earlyoom will
only log processes it is going to kill.
