### PR TITLE
Support running as local instead of dynamic user

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,3 +2,4 @@
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    systemd: 'https://github.com/camptocamp/puppet-systemd.git'

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -198,3 +198,16 @@ if true dry run (do not kill any processes) (--dryrun)
 
 Default value: ``false``
 
+##### `local_user`
+
+Data type: `Boolean`
+
+On the RedHat family of OSes the earlyoom service uses a systemd dynamic user in
+its service unit. Setting this to true will create a local system account "earlyoom"
+to run earlyoom as instead.
+On the Debian family earlyoom runs as root and this parameter is ignored.
+Note to transition from `false` to `true` it may be necessary to stop earlyoom
+so the dynamic user is not present and the local user can be added.
+
+Default value: ``false``
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,14 @@
 # @param dryrun
 #     if true dry run (do not kill any processes) (--dryrun)
 #
+# @param local_user
+#     On the RedHat family of OSes the earlyoom service uses a systemd dynamic user in
+#     its service unit. Setting this to true will create a local system account "earlyoom"
+#     to run earlyoom as instead.
+#     On the Debian family earlyoom runs as root and this parameter is ignored.
+#     Note to transition from `false` to `true` it may be necessary to stop earlyoom
+#     so the dynamic user is not present and the local user can be added.
+#
 class earlyoom (
   String[1] $pkgname                  = 'earlyoom',
   Stdlib::Unixpath $configfile        = '/etc/default/earlyoom',
@@ -92,6 +100,7 @@ class earlyoom (
   Boolean $debug                      = false,
   Boolean $priority                   = false,
   Boolean $dryrun                     = false,
+  Boolean $local_user                 = false,
   Optional[String[1]] $prefer         = undef,
   Optional[String[1]] $avoid          = undef,
   Optional[String[1]] $notify_command = undef,
@@ -99,6 +108,7 @@ class earlyoom (
   Optional[Variant[Integer[0,100],Array[Integer[0,100],2,2]]] $swap_percent   = undef,
   Optional[Variant[Integer[0],Array[Integer[0],2,2]]]         $memory_size    = undef,
   Optional[Variant[Integer[0],Array[Integer[0],2,2]]]         $swap_size      = undef,
+
 ) {
   contain 'earlyoom::install'
   contain 'earlyoom::config'

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,12 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.13.1 < 7.0.0"
+    },
+    {
+      "name": "camptocamp-systemd",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
+
   ],
   "requirements": [
     {

--- a/spec/acceptance/earlyoom_spec.rb
+++ b/spec/acceptance/earlyoom_spec.rb
@@ -25,5 +25,87 @@ describe 'earlyoom' do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
+    describe file('/etc/passwd') do
+      its(:content) { is_expected.not_to match %r{^earlyoom:.*} }
+    end
+    if fact('os.family') == 'RedHat'
+      describe process('earlyoom') do
+        its(:user) { is_expected.to eq 'earlyoom' }
+      end
+    else
+      describe process('earlyoom') do
+        its(:user) { is_expected.to eq 'root' }
+      end
+    end
+  end
+  context 'with service_enable false' do
+    let(:pp) do
+      '
+        if $facts["os"]["family"] == "RedHat" {
+          package{"epel-release":
+            ensure => present,
+            before => Class["earlyoom"]
+          }
+        }
+        class{"earlyoom":
+          service_enable => false,
+        }
+      '
+    end
+
+    it 'configures and work with no errors' do
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+    describe service('earlyoom') do
+      it { is_expected.not_to be_enabled }
+      it { is_expected.not_to be_running }
+    end
+  end
+  context 'with earlyoom and local_user true' do
+    let(:pp) do
+      '
+        if $facts["os"]["family"] == "RedHat" {
+          package{"epel-release":
+            ensure => present,
+            before => Class["earlyoom"]
+          }
+        }
+        class{"earlyoom":
+          local_user => true
+        }
+      '
+    end
+
+    it 'configures and work with no errors' do
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+    describe file('/etc/default/earlyoom') do
+      its(:content) { is_expected.to match %r{^EARLYOOM_ARGS="-r 60"$} }
+    end
+    describe service('earlyoom') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    if fact('os.family') == 'RedHat'
+      describe file('/etc/passwd') do
+        its(:content) { is_expected.to match %r{^earlyoom:.*} }
+      end
+      describe process('earlyoom') do
+        its(:user) { is_expected.to eq 'earlyoom' }
+      end
+    else
+      describe file('/etc/passwd') do
+        its(:content) { is_expected.not_to match %r{^earlyoom:.*} }
+      end
+      describe process('earlyoom') do
+        its(:user) { is_expected.to eq 'root' }
+      end
+      describe user('earlyoom') do
+        it { is_expected.not_to exist }
+      end
+    end
   end
 end


### PR DESCRIPTION
#### Support running as local instead of dynamic user

The `earlyoom` service unit on the Redhat family contains:

```ini
[Service]
DynamicUser=true
```
If local_user is specified as true (not the default) a local
user `earlyoom` will be created and systemd will be instructed to use
that user.

On Debian based earlyoom runs as root as this parameter will be ignored.

