### PR TITLE
Switch from camptocamp/systemd to voxpupli/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,4 +2,4 @@
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    systemd: 'https://github.com/camptocamp/puppet-systemd.git'
+    systemd: 'https://github.com/voxpupuli/puppet-systemd.git'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -138,6 +138,4 @@ class earlyoom::config (
     unit    => 'earlyoom.service',
     content => "#Puppet\n[Service]\nUser=earlyoom\n",
   }
-  # Needed on puppet 5 only
-  Systemd::Dropin_File['local_user.conf'] -> Class['Systemd::Systemctl::Daemon_reload']
 }

--- a/metadata.json
+++ b/metadata.json
@@ -18,8 +18,8 @@
       "version_requirement": ">= 4.13.1 < 7.0.0"
     },
     {
-      "name": "camptocamp-systemd",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     }
 
   ],


### PR DESCRIPTION
#### Pull Request (PR) description
Puppet 6 and newer calls `systemctl daemon-reload` automatically and this is no longer required
via explicit call. More over that mechanism has been removed from the systemd module
